### PR TITLE
remove bin/bash from run-prober

### DIFF
--- a/bin/run-prober
+++ b/bin/run-prober
@@ -8,4 +8,4 @@ docker run \
   -e TEST_USER_LOGIN="${TEST_USER_LOGIN}" \
   -e TEST_USER_PASSWORD="${TEST_USER_PASSWORD}" \
   civiform/civiform-browser-test:latest \
-  /bin/bash -c "yarn install && yarn probe"
+  -c "yarn install && yarn probe"


### PR DESCRIPTION
https://github.com/civiform/civiform/pull/3187 added that as an entrypoint